### PR TITLE
Fixed unknown command error on Win32

### DIFF
--- a/lib/Module/Setup/Plugin/Site/GitHub.pm
+++ b/lib/Module/Setup/Plugin/Site/GitHub.pm
@@ -4,6 +4,7 @@ use warnings;
 use base 'Module::Setup::Plugin';
 use JSON;
 use LWP::UserAgent;
+use Config;
 
 sub register {
     my($self, ) = @_;
@@ -73,9 +74,10 @@ sub finalize_create_skeleton {
             return;
         }
 
+        my $make = $Config{make};
         !$self->system('perl', 'Makefile.PL') or die $?;
-        !$self->system('make', 'test')        or die $?;
-        !$self->system('make', 'distclean')   or die $?;
+        !$self->system($make , 'test')        or die $?;
+        !$self->system($make , 'distclean')   or die $?;
         unless (-d '.git') {
             !$self->system('git', 'init')                           or die $?;
             !$self->system('git', 'add', '.')                       or die $?;

--- a/lib/Module/Setup/Plugin/Test/Makefile.pm
+++ b/lib/Module/Setup/Plugin/Test/Makefile.pm
@@ -2,6 +2,7 @@ package Module::Setup::Plugin::Test::Makefile;
 use strict;
 use warnings;
 use base 'Module::Setup::Plugin';
+use Config;
 
 sub register {
     my($self, ) = @_;
@@ -12,10 +13,11 @@ sub check_skeleton_directory {
     my $self = shift;
     return unless $self->dialog("Check Makefile.PL? [Yn] ", 'y') =~ /[Yy]/;
 
+    my $make = $Config{make};
     !$self->system('perl', 'Makefile.PL') or die $?;
-    !$self->system('make', 'test')        or die $?;
-    !$self->system('make', 'manifest')    or die $?;
-    !$self->system('make', 'distclean')   or die $?;
+    !$self->system($make , 'test')        or die $?;
+    !$self->system($make , 'manifest')    or die $?;
+    !$self->system($make , 'distclean')   or die $?;
 }
 
 1;

--- a/t/030_plugin/test_makefile.t
+++ b/t/030_plugin/test_makefile.t
@@ -1,7 +1,9 @@
 use Module::Setup::Test::Utils;
 use Test::More tests => 21;
+use Config;
 
 module_setup { init => 1 };
+my $make = $Config{make};
 
 dialog {
     my($self, $msg, $default) = @_;
@@ -22,9 +24,9 @@ dialog {
 {
     my @tests = (
         [qw/perl Makefile.PL/],
-        [qw/make test/],
-        [qw/make manifest/],
-        [qw/make distclean/],
+        [$make, 'test'],
+        [$make, 'manifest'],
+        [$make, 'distclean'],
     );
     no warnings 'redefine';
     local *Module::Setup::system = sub {
@@ -39,9 +41,9 @@ dialog {
 {
     my @tests = (
         { cmds => [qw/perl Makefile.PL/], code => 1 },
-        { cmds => [qw/make test/]       , code => 2 },
-        { cmds => [qw/make manifest/]   , code => 3 },
-        { cmds => [qw/make distclean/]  , code => 4 },
+        { cmds => [$make, 'test']       , code => 2 },
+        { cmds => [$make, 'manifest']   , code => 3 },
+        { cmds => [$make, 'distclean']  , code => 4 },
     );
     my @stack_test;
     my @pre_cmds;


### PR DESCRIPTION
I'd like to use your Module::Setup on Win32 environment.
However, perl on Win32 is usually built with 'nmake' or 'dmake' instead of 'make'.
That causes a problem when the module execute "make test" unfortunately...

I fixed the problem by using $Config{make} instead of 'make' and enjoy the Win32 programming now.
Review my code, please.

Sincerely.
