### PR TITLE
add ^MYMETA into default MANIFEST.SKIP

### DIFF
--- a/lib/Module/Setup/Flavor/Default.pm
+++ b/lib/Module/Setup/Flavor/Default.pm
@@ -142,6 +142,7 @@ template: |
   ^\.shipit$
   ^\.git/
   \.sw[po]$
+  ^MYMETA
 ---
 file: README
 template: |


### PR DESCRIPTION
The `MANIFEST.SKIP` of default flavor doesn't include pattern `^MYMETA`.
This would cause `MYMETA.yml` and `MYMETA.json` are included in `MANIFEST`.

`ShipIt::Step::DistTest` would alert these two files are not on disk but in `MANIFEST` because these two files have been removed when `ShipIt::Step::DistTest` runs `make distclean`.

Please see [ShipIt::ProjectType::Perl::Make::Maker](https://metacpan.org/source/MIYAGAWA/ShipIt-0.58/lib/ShipIt/ProjectType/Perl/MakeMaker.pm#L36) for the details.

Thanks!

shelling
