### PR TITLE
Fix a typo in PBP flavor.

### DIFF
--- a/lib/Module/Setup/Flavor/PBP.pm
+++ b/lib/Module/Setup/Flavor/PBP.pm
@@ -259,7 +259,7 @@ template: |
   
   =head1 AUTHOR
   
-  [% config.authot %]  C<< <[% config.email %]> >>
+  [% config.author %]  C<< <[% config.email %]> >>
   
   
   =head1 LICENCE AND COPYRIGHT


### PR DESCRIPTION
I fixed a typo.
This typo affects negatively effects the AUTHOR section in POD.
